### PR TITLE
Test enhancements about assertions

### DIFF
--- a/tests/DownloadGoogleTest.php
+++ b/tests/DownloadGoogleTest.php
@@ -35,7 +35,7 @@ class DownloadGoogleTest extends TestCase
 
         $this->assertTrue(count($uriClient->sitemap()->export()) > 0);
 
-        $this->assertTrue(is_string($uriClient->host()->getWithUriFallback()));
+        $this->assertInternalType('string', $uriClient->host()->getWithUriFallback());
 
         $txtClient = new RobotsTxtParser\TxtClient($uriClient->getBaseUri(), $uriClient->getStatusCode(), $uriClient->getContents(), $uriClient->getEncoding(), $uriClient->getEffectiveUri());
         $this->assertInstanceOf('vipnytt\RobotsTxtParser\TxtClient', $txtClient);

--- a/tests/DownloadMicrosoftTest.php
+++ b/tests/DownloadMicrosoftTest.php
@@ -35,7 +35,7 @@ class DownloadMicrosoftTest extends TestCase
 
         $this->assertTrue(count($uriClient->sitemap()->export()) > 0);
 
-        $this->assertTrue(is_string($uriClient->host()->getWithUriFallback()));
+        $this->assertInternalType('string', $uriClient->host()->getWithUriFallback());
 
         $txtClient = new RobotsTxtParser\TxtClient($uriClient->getBaseUri(), $uriClient->getStatusCode(), $uriClient->getContents(), $uriClient->getEncoding(), $uriClient->getEffectiveUri());
         $this->assertInstanceOf('vipnytt\RobotsTxtParser\TxtClient', $txtClient);

--- a/tests/MysqlDelayTest.php
+++ b/tests/MysqlDelayTest.php
@@ -36,18 +36,18 @@ class MysqlDelayTest extends TestCase
 
         $handler = (new RobotsTxtParser\Database($pdo))->delay();
         $parser = new RobotsTxtParser\UriClient($uri);
-        $this->assertTrue(is_numeric($parser->userAgent($userAgent)->crawlDelay()->handle($handler)->checkQueue()));
-        $this->assertTrue(is_numeric($parser->userAgent($userAgent)->crawlDelay()->handle($handler)->getTimeSleepUntil()));
-        $this->assertTrue(is_numeric($parser->userAgent($userAgent)->crawlDelay()->handle($handler)->sleep()));
+        $this->assertInternalType('numeric', $parser->userAgent($userAgent)->crawlDelay()->handle($handler)->checkQueue());
+        $this->assertInternalType('numeric', $parser->userAgent($userAgent)->crawlDelay()->handle($handler)->getTimeSleepUntil());
+        $this->assertInternalType('numeric', $parser->userAgent($userAgent)->crawlDelay()->handle($handler)->sleep());
 
         $this->assertInstanceOf('vipnytt\RobotsTxtParser\Client\Delay\ManageInterface', $handler);
         $this->assertFalse($pdo->getAttribute(\PDO::ATTR_ERRMODE) === \PDO::ERRMODE_SILENT);
 
         $client = $handler->base($uri, $userAgent, $parser->userAgent($userAgent)->crawlDelay()->getValue());
         $this->assertInstanceOf('vipnytt\RobotsTxtParser\Client\Delay\BaseInterface', $client);
-        $this->assertTrue(is_numeric($client->getTimeSleepUntil()));
+        $this->assertInternalType('numeric', $client->getTimeSleepUntil());
 
-        $this->assertTrue(is_numeric($client->checkQueue()));
+        $this->assertInternalType('numeric', $client->checkQueue());
         $start = microtime(true);
         $sleepTime = $client->sleep();
         $stop = microtime(true);
@@ -56,7 +56,7 @@ class MysqlDelayTest extends TestCase
             $sleepTime <= ($stop - $start + 1)
         );
 
-        $this->assertTrue(is_array($handler->getTopWaitTimes()));
+        $this->assertInternalType('array', $handler->getTopWaitTimes());
 
         $client->reset();
         $this->assertTrue($client->getTimeSleepUntil() === 0);

--- a/tests/RequestRateTest.php
+++ b/tests/RequestRateTest.php
@@ -33,7 +33,7 @@ class RequestRateTest extends TestCase
         foreach ($result as $value) {
             $validRates[] = $value['rate'];
         }
-        $this->assertTrue(in_array($parser->userAgent('Legacy')->requestRate()->getValue(), $validRates));
+        $this->assertContains($parser->userAgent('Legacy')->requestRate()->getValue(), $validRates);
 
         if ($rendered !== false) {
             $this->assertEquals($result, $parser->userAgent('*')->requestRate()->export());


### PR DESCRIPTION
# Changed log

- Using the `assertContains` to assert result contains expected value.
- Using the `assertInternalType` to assert expected type is same as result.